### PR TITLE
Modified VPC, Zone schema and VO files to add IPv6 attributes

### DIFF
--- a/api/src/com/cloud/dc/DataCenter.java
+++ b/api/src/com/cloud/dc/DataCenter.java
@@ -81,4 +81,9 @@ public interface DataCenter extends InfrastructureEntity, Grouping, Identity, In
     String getZoneToken();
 
     boolean isLocalStorageEnabled();
+
+    String getIp6SuperNetworkCidr();
+
+    String getAsNumber();
+
 }

--- a/api/src/com/cloud/network/vpc/Vpc.java
+++ b/api/src/com/cloud/network/vpc/Vpc.java
@@ -87,4 +87,10 @@ public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
      * @return true if VPC spans multiple zones in the region
      */
     boolean isRegionLevelVpc();
+
+    /**
+     *
+     * @return IPv6 CIDR of the VPC
+     */
+    String getIp6Cidr();
 }

--- a/engine/orchestration/src/org/apache/cloudstack/engine/datacenter/entity/api/db/EngineDataCenterVO.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/datacenter/entity/api/db/EngineDataCenterVO.java
@@ -82,6 +82,12 @@ public class EngineDataCenterVO implements EngineDataCenter, Identity {
     @Column(name = "guest_network_cidr")
     private String guestNetworkCidr = null;
 
+    @Column(name = "ip6_super_network_cidr")
+    private String ip6SuperNetworkCidr = null;
+
+    @Column(name = "as_number")
+    private String asNumber  = null;
+
     @Column(name = "domain_id")
     private Long domainId = null;
 
@@ -210,14 +216,14 @@ public class EngineDataCenterVO implements EngineDataCenter, Identity {
 
     public EngineDataCenterVO(long id, String name, String description, String dns1, String dns2, String dns3, String dns4, String guestCidr, String domain,
             Long domainId, NetworkType zoneType, String zoneToken, String domainSuffix) {
-        this(name, description, dns1, dns2, dns3, dns4, guestCidr, domain, domainId, zoneType, zoneToken, domainSuffix, false, false, null, null);
+        this(name, description, dns1, dns2, dns3, dns4, guestCidr, domain, domainId, zoneType, zoneToken, domainSuffix, false, false, null, null, null, null);
         this.id = id;
         this.allocationState = Grouping.AllocationState.Enabled;
         this.uuid = UUID.randomUUID().toString();
     }
 
     public EngineDataCenterVO(String name, String description, String dns1, String dns2, String dns3, String dns4, String guestCidr, String domain, Long domainId,
-            NetworkType zoneType, String zoneToken, String domainSuffix, boolean securityGroupEnabled, boolean localStorageEnabled, String ip6Dns1, String ip6Dns2) {
+            NetworkType zoneType, String zoneToken, String domainSuffix, boolean securityGroupEnabled, boolean localStorageEnabled, String ip6Dns1, String ip6Dns2, String ip6SuperNetworkCidr, String asNumber) {
         this.name = name;
         this.description = description;
         this.dns1 = dns1;
@@ -225,6 +231,8 @@ public class EngineDataCenterVO implements EngineDataCenter, Identity {
         this.internalDns1 = dns3;
         this.internalDns2 = dns4;
         this.guestNetworkCidr = guestCidr;
+        this.ip6SuperNetworkCidr = ip6SuperNetworkCidr;
+        this.asNumber = asNumber;
         this.domain = domain;
         this.domainId = domainId;
         this.networkType = zoneType;
@@ -502,5 +510,23 @@ public class EngineDataCenterVO implements EngineDataCenter, Identity {
 
     public void setIp6Dns2(String ip6Dns2) {
         this.ip6Dns2 = ip6Dns2;
+    }
+
+    @Override
+    public String getIp6SuperNetworkCidr() {
+        return ip6SuperNetworkCidr;
+    }
+
+    public void setIp6SuperNetworkCidr(String ip6GuestNetworkCidr) {
+        this.ip6SuperNetworkCidr = ip6GuestNetworkCidr;
+    }
+
+    @Override
+    public String getAsNumber() {
+        return asNumber;
+    }
+
+    public void setAsNumber(String asNumber) {
+        this.asNumber = asNumber;
     }
 }

--- a/engine/orchestration/test/org/apache/cloudstack/engine/provisioning/test/ProvisioningTest.java
+++ b/engine/orchestration/test/org/apache/cloudstack/engine/provisioning/test/ProvisioningTest.java
@@ -75,7 +75,7 @@ public class ProvisioningTest extends TestCase {
     public void setUp() {
         EngineDataCenterVO dc =
             new EngineDataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null,
-                true, true, null, null);
+                true, true, null, null, null, null);
         Mockito.when(dcDao.findByUuid(Matchers.anyString())).thenReturn(dc);
         Mockito.when(dcDao.persist((EngineDataCenterVO)Matchers.anyObject())).thenReturn(dc);
 

--- a/engine/schema/src/com/cloud/dc/DataCenterVO.java
+++ b/engine/schema/src/com/cloud/dc/DataCenterVO.java
@@ -75,6 +75,12 @@ public class DataCenterVO implements DataCenter {
     @Column(name = "guest_network_cidr")
     private String guestNetworkCidr = null;
 
+    @Column(name = "ip6_super_network_cidr")
+    private String ip6SuperNetworkCidr = null;
+
+    @Column(name = "as_number")
+    private String asNumber  = null;
+
     @Column(name = "domain_id")
     private Long domainId = null;
 
@@ -182,14 +188,14 @@ public class DataCenterVO implements DataCenter {
 
     public DataCenterVO(long id, String name, String description, String dns1, String dns2, String dns3, String dns4, String guestCidr, String domain, Long domainId,
             NetworkType zoneType, String zoneToken, String domainSuffix) {
-        this(name, description, dns1, dns2, dns3, dns4, guestCidr, domain, domainId, zoneType, zoneToken, domainSuffix, false, false, null, null);
+        this(name, description, dns1, dns2, dns3, dns4, guestCidr, domain, domainId, zoneType, zoneToken, domainSuffix, false, false, null, null, null, null);
         this.id = id;
         this.allocationState = Grouping.AllocationState.Enabled;
         this.uuid = UUID.randomUUID().toString();
     }
 
     public DataCenterVO(String name, String description, String dns1, String dns2, String dns3, String dns4, String guestCidr, String domain, Long domainId,
-            NetworkType zoneType, String zoneToken, String domainSuffix, boolean securityGroupEnabled, boolean localStorageEnabled, String ip6Dns1, String ip6Dns2) {
+            NetworkType zoneType, String zoneToken, String domainSuffix, boolean securityGroupEnabled, boolean localStorageEnabled, String ip6Dns1, String ip6Dns2, String ip6SuperCidr, String asNumber) {
         this.name = name;
         this.description = description;
         this.dns1 = dns1;
@@ -199,6 +205,8 @@ public class DataCenterVO implements DataCenter {
         this.internalDns1 = dns3;
         this.internalDns2 = dns4;
         this.guestNetworkCidr = guestCidr;
+        this.ip6SuperNetworkCidr = ip6SuperCidr;
+        this.asNumber = asNumber;
         this.domain = domain;
         this.domainId = domainId;
         this.networkType = zoneType;
@@ -455,5 +463,23 @@ public class DataCenterVO implements DataCenter {
 
     public void setIp6Dns2(String ip6Dns2) {
         this.ip6Dns2 = ip6Dns2;
+    }
+
+    @Override
+    public String getIp6SuperNetworkCidr() {
+        return ip6SuperNetworkCidr;
+    }
+
+    public void setIp6SuperNetworkCidr(String ip6GuestNetworkCidr) {
+        this.ip6SuperNetworkCidr = ip6GuestNetworkCidr;
+    }
+
+    @Override
+    public String getAsNumber() {
+        return asNumber;
+    }
+
+    public void setAsNumber(String asNumber) {
+        this.asNumber = asNumber;
     }
 }

--- a/engine/schema/src/com/cloud/network/vpc/VpcVO.java
+++ b/engine/schema/src/com/cloud/network/vpc/VpcVO.java
@@ -51,6 +51,9 @@ public class VpcVO implements Vpc {
     @Column(name = "cidr")
     private String cidr = null;
 
+    @Column(name = "ip6_cidr")
+    private String ip6Cidr = null;
+
     @Column(name = "domain_id")
     Long domainId = null;
 
@@ -94,13 +97,14 @@ public class VpcVO implements Vpc {
 
     public VpcVO(final long zoneId, final String name, final String displayText, final long accountId, final long domainId,
             final long vpcOffId, final String cidr, final String networkDomain, final boolean useDistributedRouter,
-            final boolean regionLevelVpc, final boolean isRedundant) {
+            final boolean regionLevelVpc, final boolean isRedundant, String ip6Cidr) {
         this.zoneId = zoneId;
         this.name = name;
         this.displayText = displayText;
         this.accountId = accountId;
         this.domainId = domainId;
         this.cidr = cidr;
+        this.ip6Cidr = ip6Cidr;
         uuid = UUID.randomUUID().toString();
         state = State.Enabled;
         this.networkDomain = networkDomain;
@@ -236,5 +240,10 @@ public class VpcVO implements Vpc {
     @Override
     public boolean usesDistributedRouter() {
         return usesDistributedRouter;
+    }
+
+    @Override
+    public String getIp6Cidr() {
+        return ip6Cidr;
     }
 }

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/VmwareDatacenterApiUnitTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/VmwareDatacenterApiUnitTest.java
@@ -167,7 +167,7 @@ public class VmwareDatacenterApiUnitTest {
 
         DataCenterVO zone =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         zoneId = 1L;
 
         HostPodVO pod = new HostPodVO(UUID.randomUUID().toString(), zoneId, "192.168.56.1", "192.168.56.0/24", 8, "test");

--- a/plugins/storage/volume/solidfire/test/org/apache/cloudstack/storage/test/VolumeTest.java
+++ b/plugins/storage/volume/solidfire/test/org/apache/cloudstack/storage/test/VolumeTest.java
@@ -76,7 +76,7 @@ public class VolumeTest {
         // create data center
         DataCenterVO dc =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         dc = dcDao.persist(dc);
         dcId = dc.getId();
         // create pod

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1826,7 +1826,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         // Create the new zone in the database
         final DataCenterVO zoneFinal = new DataCenterVO(zoneName, null, dns1, dns2, internalDns1, internalDns2, guestCidr, domain, domainId, zoneType, zoneToken, networkDomain,
-                isSecurityGroupEnabled, isLocalStorageEnabled, ip6Dns1, ip6Dns2);
+                isSecurityGroupEnabled, isLocalStorageEnabled, ip6Dns1, ip6Dns2, null, null);
         if (allocationStateStr != null && !allocationStateStr.isEmpty()) {
             final Grouping.AllocationState allocationState = Grouping.AllocationState.valueOf(allocationStateStr);
             zoneFinal.setAllocationState(allocationState);

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -816,7 +816,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         final boolean useDistributedRouter = vpcOff.supportsDistributedRouter();
         final VpcVO vpc = new VpcVO(zoneId, vpcName, displayText, owner.getId(), owner.getDomainId(), vpcOffId,
-                cidr, networkDomain, useDistributedRouter, isRegionLevelVpcOff, vpcOff.getRedundantRouter());
+                cidr, networkDomain, useDistributedRouter, isRegionLevelVpcOff, vpcOff.getRedundantRouter(), null);
 
         return createVpc(displayVpc, vpc);
     }

--- a/server/test/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/test/com/cloud/configuration/ConfigurationManagerTest.java
@@ -241,7 +241,7 @@ public class ConfigurationManagerTest {
 
         DataCenterVO dc =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         List<IPAddressVO> ipAddressList = new ArrayList<IPAddressVO>();
@@ -285,7 +285,7 @@ public class ConfigurationManagerTest {
 
         DataCenterVO dc =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         List<IPAddressVO> ipAddressList = new ArrayList<IPAddressVO>();
@@ -312,7 +312,7 @@ public class ConfigurationManagerTest {
         // public ip range belongs to zone of type basic
         DataCenterVO dc =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         List<IPAddressVO> ipAddressList = new ArrayList<IPAddressVO>();
@@ -338,7 +338,7 @@ public class ConfigurationManagerTest {
 
         DataCenterVO dc =
             new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+                true, null, null, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         // one of the ip addresses of the range is allocated to different account

--- a/server/test/com/cloud/vpc/VpcApiUnitTest.java
+++ b/server/test/com/cloud/vpc/VpcApiUnitTest.java
@@ -85,7 +85,7 @@ public class VpcApiUnitTest extends TestCase {
     public void validateNtwkOffForVpc() {
         //validate network offering
         //1) correct network offering
-        VpcVO vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false);
+        VpcVO vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, null);
         boolean result = false;
         try {
             _vpcService.validateNtwkOffForNtwkInVpc(2L, 1, "0.0.0.0", "111-", vo, "10.1.1.1", new AccountVO(), null);

--- a/server/test/com/cloud/vpc/dao/MockVpcDaoImpl.java
+++ b/server/test/com/cloud/vpc/dao/MockVpcDaoImpl.java
@@ -98,9 +98,9 @@ public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDa
     public VpcVO findById(Long id) {
         VpcVO vo = null;
         if (id.longValue() == 1) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false);
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, null);
         } else if (id.longValue() == 2) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false);
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, null);
             vo.setState(State.Inactive);
         }
 

--- a/setup/db/db/schema-451to460.sql
+++ b/setup/db/db/schema-451to460.sql
@@ -398,3 +398,7 @@ CREATE TABLE `cloud`.`external_bigswitch_bcf_devices` (
   CONSTRAINT `fk_external_bigswitch_bcf_devices__host_id` FOREIGN KEY (`host_id`) REFERENCES `host`(`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_external_bigswitch_bcf_devices__physical_network_id` FOREIGN KEY (`physical_network_id`) REFERENCES `physical_network`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ALTER TABLE `cloud`.`data_center` ADD COLUMN `ip6_super_network_cidr` varchar(255);
+ALTER TABLE `cloud`.`data_center` ADD COLUMN `as_number` varchar(255);
+ALTER TABLE `cloud`.`vpc` ADD COLUMN `ip6_cidr` varchar(255);

--- a/setup/db/db/schema-451to460.sql
+++ b/setup/db/db/schema-451to460.sql
@@ -399,6 +399,6 @@ CREATE TABLE `cloud`.`external_bigswitch_bcf_devices` (
   CONSTRAINT `fk_external_bigswitch_bcf_devices__physical_network_id` FOREIGN KEY (`physical_network_id`) REFERENCES `physical_network`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-ALTER TABLE `cloud`.`data_center` ADD COLUMN `ip6_super_network_cidr` varchar(255);
-ALTER TABLE `cloud`.`data_center` ADD COLUMN `as_number` varchar(255);
-ALTER TABLE `cloud`.`vpc` ADD COLUMN `ip6_cidr` varchar(255);
+ALTER TABLE `cloud`.`data_center` ADD COLUMN `ip6_super_network_cidr` varchar(50);
+ALTER TABLE `cloud`.`data_center` ADD COLUMN `as_number` varchar(15);
+ALTER TABLE `cloud`.`vpc` ADD COLUMN `ip6_cidr` varchar(50);


### PR DESCRIPTION
I have made following changes
 a) Modified 4.5.1 to 4.6 upgrade scripts to alter vpc and data_center table to add IPv6 related attributes 
 b) Modified VO corresponding to Vpc and Zone to reflect the new attributes
 c) Modified dependent Test files that use VpcVO and DataCenterVO constructors